### PR TITLE
fix/etl-routes-method

### DIFF
--- a/app/api/etl/collect/route.ts
+++ b/app/api/etl/collect/route.ts
@@ -1,6 +1,6 @@
 import AnalyticsDataCollector from "@/lib/AnalyticsDataCollector";
 
-export async function GET() {
+export async function POST() {
   try {
     const adc = new AnalyticsDataCollector();
 

--- a/app/api/etl/process/route.ts
+++ b/app/api/etl/process/route.ts
@@ -1,6 +1,6 @@
 import AnalyticsDataProcessor from "@/lib/AnalyticsDataProcessor";
 
-export async function GET() {
+export async function POST() {
   try {
     const adp = new AnalyticsDataProcessor();
 

--- a/app/api/ews/update/route.ts
+++ b/app/api/ews/update/route.ts
@@ -1,6 +1,6 @@
 import EarlyWarningSystem from "@/lib/EarlyWarningSystem";
 
-export async function GET() {
+export async function POST() {
   try {
     const ews = new EarlyWarningSystem();
 


### PR DESCRIPTION
Use `POST` over `GET` to prevent static generation of the ETL API routes during `next build`